### PR TITLE
add windows instructions; ignore secrets.yaml explicitly; fix pointer…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-
+# ignore wifi credentials
+secrets.yaml
 sample printer output.txt
 *.txt

--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@ Current Status:
 ![Untitled](https://user-images.githubusercontent.com/10102873/147993815-92dd5a8d-6161-4f82-92d9-c3f3c9e52dda.png)
 
 
+# WINDOWS 10:
+# follow instructions here:
+https://esphome.io/guides/installing_esphome.html
+# create secrets.yaml file
+# then do this or similar:
+esphome run esphome-ge-dryer-uart.yml
+
+# Windows 10 (msys2) non-working instructions
+# WARNING: does not work as eventually fails with termios dependency problem
+pacman -Syu
+pacman -S pactoys
+pacboy -S python python-pip python-devel python-cryptography rust
+pip install esphome
+
 TODO:
 
 - Add #define or options of some sort to configure header for either washer or dryer.

--- a/esphome-ge-washer-uart.h
+++ b/esphome-ge-washer-uart.h
@@ -216,7 +216,7 @@ class component_geUART :
         this->textsensor_DoorLock= new TextSensor();  
     }
     
-    uint16_t crc16geabus_bit(uint16_t crc, void const *mem, size_t len) {
+    uint16_t crc16geabus_bit(uint16_t crc, unsigned char const *mem, size_t len) {
         unsigned char const *data = mem;
         if (data == NULL)
             return 0xe300;

--- a/esphome-ge-washer-uart.yml
+++ b/esphome-ge-washer-uart.yml
@@ -24,10 +24,10 @@ wifi:
   password: !secret wifi_password
   
   # Optional manual IP
-  manual_ip:
-    static_ip: 192.168.0.192
-    gateway: 192.168.0.9
-    subnet: 255.255.255.0
+ # manual_ip:
+ #   static_ip: 192.168.0.192
+ #   gateway: 192.168.0.9
+ #   subnet: 255.255.255.0
 
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   #ap:


### PR DESCRIPTION
Probably too may things for one commit.
Mainly wanted to add to readme to help windows users.

Also I do not know how to set -fpermissive with esphome so just changed void pointer to explicit type so compilation completes for washer. I do not see where crc16geabus_bit() is invoked anyway.